### PR TITLE
Add custom find override demo

### DIFF
--- a/src/app/extended-pdf-viewer/custom-find/custom-find.component.html
+++ b/src/app/extended-pdf-viewer/custom-find/custom-find.component.html
@@ -1,0 +1,50 @@
+
+<article class="custom-find-wrapper pdf-wrapper flex-container-column fill-container">
+  <div class="pdf-code-wrapper flex-container-row" >
+    <mat-card appearance="outlined" class="overflow-none distance16 mat-elevation-z8 margin-right" style="flex: 1 1 100%; box-sizing: border-box; max-width:30%">
+      <div class="flex-container-column">
+        <p>
+          Demonstration of customizing the find functionality.
+          This works by overiding the default find functionality of the pdfjs viewer;
+          in this example adding support for regex search.
+        </p>
+        <p>
+          <b>Note:</b> This is a simple demo does not protect against invalid regex.
+        </p>
+
+        <mat-form-field>
+          <input matInput class="margin" [(ngModel)]="searchtext" placeholder="Regex Search Term" />
+        </mat-form-field>
+        <div class="row">
+          <button mat-raised-button color="primary" (click)="findRegex()">Find</button>
+          <button mat-raised-button color="primary" (click)="findNext()">Next</button>
+          <button mat-raised-button color="primary" (click)="findPrevious()">Previous</button>
+        </div>
+        <small class="row">
+          <span style="margin-left: 24px" *ngIf="totalMatches && totalMatches > 0">Result {{ currentMatchNumber }} of {{ totalMatches }} </span>
+        </small>
+      </div>
+    </mat-card>
+
+    <mat-card appearance="outlined" class="overflow-y-scroll distance16 mat-elevation-z8 progress" style="flex: 1 1 100%; box-sizing: border-box; max-width:69%">
+      <mat-tab-group>
+        <mat-tab label="HTML template">
+          <app-ie11-markdown src="/assets/extended-pdf-viewer/custom-find/html.md"> </app-ie11-markdown>
+        </mat-tab>
+        <mat-tab label="TypeScript">
+          <app-ie11-markdown src="/assets/extended-pdf-viewer/custom-find/ts.md"> </app-ie11-markdown>
+        </mat-tab>
+      </mat-tab-group>
+    </mat-card>
+  </div>
+
+  <mat-card appearance="outlined" class="pdf-card distance16 mat-elevation-z8 use-available-space">
+    <ngx-extended-pdf-viewer
+      src="/assets/pdfs/Portugues-para-principiantes-1538054164.pdf"
+      [textLayer]="true"
+      [showFindButton]="false"
+      (updateFindMatchesCount)="onUpdateFindMatchesCount($event)"
+      (pdfLoaded)="pdfLoaded()">
+    </ngx-extended-pdf-viewer>
+  </mat-card>
+</article>

--- a/src/app/extended-pdf-viewer/custom-find/custom-find.component.html
+++ b/src/app/extended-pdf-viewer/custom-find/custom-find.component.html
@@ -5,8 +5,9 @@
       <div class="flex-container-column">
         <p>
           Demonstration of customizing the find functionality.
-          This works by overiding the default find functionality of the pdfjs viewer;
+          This works by overriding the default find functionality of the pdfjs viewer;
           in this example adding support for regex search.
+          A more complete implementation would provide a custom find bar.
         </p>
         <p>
           <b>Note:</b> This is a simple demo does not protect against invalid regex.

--- a/src/app/extended-pdf-viewer/custom-find/custom-find.component.scss
+++ b/src/app/extended-pdf-viewer/custom-find/custom-find.component.scss
@@ -1,0 +1,10 @@
+.custom-find-wrapper {
+  .row {
+    margin-bottom: 5px;
+
+    button {
+      width: 30%;
+      margin-left: 5px;
+    }
+  }
+}

--- a/src/app/extended-pdf-viewer/custom-find/custom-find.component.ts
+++ b/src/app/extended-pdf-viewer/custom-find/custom-find.component.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { FindOptions, FindResultMatchesCount, IPDFViewerApplication, NgxExtendedPdfViewerService } from 'ngx-extended-pdf-viewer';
+
+interface CustomFindOptions extends FindOptions {
+  matchRegex: boolean;
+}
+
+@Component({
+  selector: 'app-custom-find',
+  templateUrl: './custom-find.component.html',
+  styleUrls: ['./custom-find.component.scss'],
+})
+export class CustomFindComponent {
+  searchtext = '(?<=\\s)([A-z]+ough)';
+  findOptions: CustomFindOptions = {
+    highlightAll: true,
+    matchCase: false,
+    wholeWords: false,
+    matchDiacritics: false,
+    matchRegex: true,
+  };
+
+  currentMatchNumber: number | undefined;
+  totalMatches: number | undefined;
+
+  private originalConvertToRegExpString: any;
+
+  get pdfViewerApplication(): IPDFViewerApplication {
+    return (window as any).PDFViewerApplication;
+  }
+
+  constructor(private readonly cdr: ChangeDetectorRef) {  }
+
+  pdfLoaded() {
+    this.overideFindFeature();
+  }
+
+  ngOnDestroy() {
+    this.restoreFindFeature();
+  }
+
+  findRegex() {
+    this.dispatchFind('find');
+  }
+
+  findNext(): void {
+    this.dispatchFind('again', false);
+  }
+
+  findPrevious(): void {
+    this.dispatchFind('again', true);
+  }
+
+  public onUpdateFindMatchesCount(result: FindResultMatchesCount) {
+    this.currentMatchNumber = result.current;
+    this.totalMatches = result.total;
+    this.cdr.detectChanges();
+  }
+
+  private overideFindFeature() {
+    const findController = this.pdfViewerApplication.findController as any;
+
+    this.originalConvertToRegExpString = findController._convertToRegExpString;
+    findController._convertToRegExpString = (query: string, ...args: any[]) => {
+      const { matchRegex } = findController.state;
+
+      if (!matchRegex) return this.originalConvertToRegExpString.call(findController, query, ...args);
+      return [false, query];
+    };
+  }
+
+  private restoreFindFeature() {
+    if (this.originalConvertToRegExpString) {
+      const findController = this.pdfViewerApplication.findController as any;
+      findController._convertToRegExpString = this.originalConvertToRegExpString;
+    }
+  }
+
+  private dispatchFind(type: string, findPrevious = false): void {
+    this.pdfViewerApplication.eventBus.dispatch('find', {
+      ...this.findOptions,
+      query: this.searchtext,
+      type,
+      findPrevious,
+      source: undefined
+    });
+  }
+}

--- a/src/app/extended-pdf-viewer/custom-find/html.md
+++ b/src/app/extended-pdf-viewer/custom-find/html.md
@@ -1,0 +1,9 @@
+```html
+<ngx-extended-pdf-viewer
+  src="/assets/pdfs/Portugues-para-principiantes-1538054164.pdf"
+  [textLayer]="true"
+  [showFindButton]="false"
+  (updateFindMatchesCount)="onUpdateFindMatchesCount($event)"
+  (pdfLoaded)="pdfLoaded()">
+</ngx-extended-pdf-viewer>
+```

--- a/src/app/extended-pdf-viewer/custom-find/ts.md
+++ b/src/app/extended-pdf-viewer/custom-find/ts.md
@@ -1,0 +1,68 @@
+```ts
+interface CustomFindOptions extends FindOptions {
+  matchRegex: boolean;
+}
+
+@Component({...})
+export class CustomFindComponent {
+  searchtext = '(?<=\\s)([A-z]+ough)';
+  findOptions: CustomFindOptions = {
+    highlightAll: true,
+    matchCase: false,
+    wholeWords: false,
+    matchDiacritics: false,
+    matchRegex: true
+  };
+
+  // Override the find feature to support regex after the PDF is loaded
+  pdfLoaded() {
+    this.overrideFindFeature();
+  }
+
+  // Optional: Restore the original find feature
+  ngOnDestroy() {
+    this.restoreFindFeature();
+  }
+
+  findRegex() {
+    this.dispatchFind('find');
+  }
+
+  findNext(): void {
+    this.dispatchFind('again', false);
+  }
+
+  findPrevious(): void {
+    this.dispatchFind('again', true);
+  }
+
+  /**
+   * Override the find feature to support regex
+   */
+  private overrideFindFeature() {
+    const findController = this.pdfViewerApplication.findController as any;
+
+    const originalConvertToRegExpString = findController._convertToRegExpString;
+    findController._convertToRegExpString = (query: string, ...args: any[]) => {
+      const { matchRegex } = findController.state;
+
+      // If not matchRegex, call the original method
+      if (!matchRegex) return originalConvertToRegExpString.call(findController, query, ...args);
+
+      // If matchRegex, return the query as is
+      return [false, query];
+    };
+  }
+
+  // Need to use dispatch directly
+  private dispatchFind(type: string, findPrevious = false): void {
+    this.pdfViewerApplication.eventBus.dispatch('find', {
+      ...this.findOptions,
+      query: this.searchtext,
+      type,
+      findPrevious,
+      source: undefined
+    });
+  }
+}
+```

--- a/src/app/extended-pdf-viewer/extended-pdf-viewer-routing.module.ts
+++ b/src/app/extended-pdf-viewer/extended-pdf-viewer-routing.module.ts
@@ -67,6 +67,7 @@ import { AnnotationLayerComponent } from './annotation-layer/annotation-layer.co
 import { SecurityComponent } from './security/security.component';
 import { AnnotationLayerApiComponent } from './annotation-layer-api/annotation-layer-api.component';
 import { EditorSettingsComponent } from './editor-settings/editor-settings.component';
+import { CustomFindComponent } from './custom-find/custom-find.component';
 
 const routes: Routes = [
   {
@@ -90,6 +91,7 @@ const routes: Routes = [
   { path: 'custom-toolbar', component: CustomToolbarComponent },
   { path: 'custom-sidebar', component: CustomSidebarComponent },
   { path: 'custom-thumbnails', component: CustomThumbnailsComponent },
+  { path: 'custom-find', component: CustomFindComponent },
   { path: 'display-options', component: DisplayOptionsComponent },
   { path: 'export-file', component: ExportFileComponent },
   { path: 'export-image', component: ExportImageComponent },

--- a/src/app/extended-pdf-viewer/extended-pdf-viewer.module.ts
+++ b/src/app/extended-pdf-viewer/extended-pdf-viewer.module.ts
@@ -73,6 +73,7 @@ import { AnnotationLayerComponent } from './annotation-layer/annotation-layer.co
 import { SecurityComponent } from './security/security.component';
 import { AnnotationLayerApiComponent } from './annotation-layer-api/annotation-layer-api.component';
 import { EditorSettingsComponent } from './editor-settings/editor-settings.component';
+import { CustomFindComponent } from './custom-find/custom-find.component';
 
 
 new TouchEmulator();
@@ -94,6 +95,7 @@ new TouchEmulator();
     CustomPrintDialogComponent,
     CustomRenderComponent,
     CustomSidebarComponent,
+    CustomFindComponent,
     CustomThumbnailsComponent,
     CustomToolbarComponent,
     DefaultOptionsComponent,

--- a/src/app/nav/extended-pdf-viewer-menu/extended-pdf-viewer-menu.component.html
+++ b/src/app/nav/extended-pdf-viewer-menu/extended-pdf-viewer-menu.component.html
@@ -35,6 +35,7 @@
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'responsive-design'">Responsive design</a>
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'custom-toolbar'">Custom toolbars</a>
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'custom-sidebar'">Custom sidebar</a>
+  <a mat-list-item (click)="toggleDrawer()" [routerLink]="'custom-find'">Custom find</a>
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'custom-thumbnails'">Custom thumbnails</a>
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'display-options'">Display options</a>
   <a mat-list-item (click)="toggleDrawer()" [routerLink]="'scripting'">enable / disable JavaScript</a>


### PR DESCRIPTION
This PR adds a minimal example of overriding the pdfjs find controller for custom search.

![image](https://github.com/stephanrauh/extended-pdf-viewer-showcase/assets/509946/f6f76618-b861-420f-9567-47a49d5cb98b)
