### PR TITLE
Improve page structure

### DIFF
--- a/src/app/nav/nav.component.css
+++ b/src/app/nav/nav.component.css
@@ -3,7 +3,8 @@
 }
 
 .sidenav {
-  width: 200px;
+  width: 33vw;
+  max-width: 400px;
 }
 
 .sidenav .mat-toolbar {

--- a/src/app/nav/nav.component.css
+++ b/src/app/nav/nav.component.css
@@ -1,9 +1,19 @@
+.page {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas: 'toolbar' 'content';
+}
+
+.toolbar {
+  grid-area: toolbar;
+}
+
 .sidenav-container {
   height: 100%;
+  grid-area: content;
 }
 
 .sidenav {
-  width: 33vw;
   max-width: 400px;
 }
 
@@ -23,7 +33,6 @@
   height: calc(100vh - 85px);
 }
 
-
 .mat-toolbar.mat-primary {
   z-index: 11;
 }
@@ -37,9 +46,9 @@
   color: blue;
 }
 
-.mat-toolbar-single-row {
-  height: 48px;
-  padding-top: 24px;
+.toolbar-row {
+  height: unset;
+  display: block;
 }
 
 .mat-nav-list a.mat-mdc-list-item.long-text {
@@ -55,26 +64,25 @@
   padding-left: 16px;
 }
 
-.mat-sidenav {
-  padding-top: 48px;
-}
-
 .toolbar {
   padding-block: 0.5rem;
 }
 
-.first-row {
+.toolbar-row-content {
   display: grid;
   grid-template-columns: auto minmax(0,1fr);
   align-items: center;
   gap: 1rem
 }
 
-.inner-row {
+.toolbar-row-content-inner-row {
   display: grid;
-  grid-template-rows: 1fr 1fr;
 }
 
-::ng-deep .inner-row .mat-mdc-radio-button .mdc-form-field {
+.toolbar-row-content-inner-row span {
+  text-wrap: wrap;
+}
+
+::ng-deep .toolbar-row-content-inner-row .mat-mdc-radio-button .mdc-form-field {
   color: white;
 }

--- a/src/app/nav/nav.component.css
+++ b/src/app/nav/nav.component.css
@@ -59,20 +59,22 @@
   padding-top: 48px;
 }
 
-.second-row {
-  margin-top: -16px;
-  padding-bottom: 8px;
+.toolbar {
+  padding-block: 0.5rem;
 }
 
-.first-row,.second-row {
-  height: 50px;
+.first-row {
+  display: grid;
+  grid-template-columns: auto minmax(0,1fr);
+  align-items: center;
+  gap: 1rem
 }
 
-.side-nav-toggle {
-  margin-left: -11px;
-  zoom: 133%
+.inner-row {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
 }
 
-::ng-deep .second-row .mat-mdc-radio-button .mdc-form-field {
+::ng-deep .inner-row .mat-mdc-radio-button .mdc-form-field {
   color: white;
 }

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -5,16 +5,17 @@
 }
 
 @if (!hideMenu) {
-  <div>
+  <div class="page">
     <mat-toolbar color="primary" class="mat-elevation-z8 toolbar">
-      <mat-toolbar-row>
+      <mat-toolbar-row class="toolbar-row">
         <app-octocat></app-octocat>
-        <div class="first-row">
+        <div class="toolbar-row-content">
           <button type="button" aria-label="Toggle sidenav" mat-icon-button (click)="drawer.toggle()">
             <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
           </button>
-          <div class="inner-row">
-            <span>Angular PDF viewer showcase. Running on Angular {{ angularVersion }}{{ pdfjsVersion }} and {{ library }} {{ version }}.</span>
+          <div class="toolbar-row-content-inner-row">
+            <span>Angular PDF viewer showcase. Running on Angular {{ angularVersion }}{{ pdfjsVersion }} and {{ library }} {{ version }}
+              .</span>
             <mat-radio-group aria-label="Demo" [(ngModel)]="viewer">
               Choose a version:
               <mat-radio-button class="distance16" value="ngx-extended-pdf-viewer">stable (based on pdf.js 4.5)</mat-radio-button>
@@ -23,19 +24,20 @@
           </div>
         </div>
 
-        </mat-toolbar-row>
-      </mat-toolbar>
-      <mat-sidenav-container class="sidenav-container">
-        <mat-sidenav #drawer class="sidenav" fixedInViewport="true" [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'" [mode]="'side'" [opened]="true">
-          @if (ngxExtendedPdfViewer) {
-            <app-extended-pdf-viewer-menu [drawer]="drawer"></app-extended-pdf-viewer-menu>
-          }
-        </mat-sidenav>
-        <mat-sidenav-content>
-          <div class="with-border">
-            <router-outlet></router-outlet>
-          </div>
-        </mat-sidenav-content>
-      </mat-sidenav-container>
-    </div>
-  }
+      </mat-toolbar-row>
+    </mat-toolbar>
+    <mat-sidenav-container class="sidenav-container">
+      <mat-sidenav #drawer class="sidenav" [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
+                   [mode]="'side'" [opened]="true">
+        @if (ngxExtendedPdfViewer) {
+          <app-extended-pdf-viewer-menu [drawer]="drawer"></app-extended-pdf-viewer-menu>
+        }
+      </mat-sidenav>
+      <mat-sidenav-content>
+        <div class="with-border">
+          <router-outlet></router-outlet>
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
+  </div>
+}

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -6,22 +6,23 @@
 
 @if (!hideMenu) {
   <div>
-    <mat-toolbar color="primary" class="mat-elevation-z8">
-      <mat-toolbar-row class="first-row">
+    <mat-toolbar color="primary" class="mat-elevation-z8 toolbar">
+      <mat-toolbar-row>
         <app-octocat></app-octocat>
-        <span style="left: 65px; position: absolute"
-          >Angular PDF viewer showcase. Running on Angular {{ angularVersion }}{{ pdfjsVersion }} and {{ library }} {{ version }}.</span
-          >
-        </mat-toolbar-row>
-        <mat-toolbar-row class="second-row">
-          <button type="button" class="side-nav-toggle" aria-label="Toggle sidenav" mat-icon-button (click)="drawer.toggle()">
+        <div class="first-row">
+          <button type="button" aria-label="Toggle sidenav" mat-icon-button (click)="drawer.toggle()">
             <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
           </button>
-          <mat-radio-group aria-label="Demo" [(ngModel)]="viewer" style="left: 65px; position: absolute">
-            Choose a version:
-            <mat-radio-button class="distance16" value="ngx-extended-pdf-viewer">stable (based on pdf.js 4.5)</mat-radio-button>
-            <mat-radio-button class="distance16" value="bleeding-edge">bleeding edge (sneak preview of pdf.js 4.6)</mat-radio-button>
-          </mat-radio-group>
+          <div class="inner-row">
+            <span>Angular PDF viewer showcase. Running on Angular {{ angularVersion }}{{ pdfjsVersion }} and {{ library }} {{ version }}.</span>
+            <mat-radio-group aria-label="Demo" [(ngModel)]="viewer">
+              Choose a version:
+              <mat-radio-button class="distance16" value="ngx-extended-pdf-viewer">stable (based on pdf.js 4.5)</mat-radio-button>
+              <mat-radio-button class="distance16" value="bleeding-edge">bleeding edge (sneak preview of pdf.js 4.6)</mat-radio-button>
+            </mat-radio-group>
+          </div>
+        </div>
+
         </mat-toolbar-row>
       </mat-toolbar>
       <mat-sidenav-container class="sidenav-container">

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
     <!-- <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types default pdf-viewer dompurify angular angular#unsafe-bypass angular#bundler; default-src 'self'; script-src 'self' *; connect-src *; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src *; object-src 'none'"> -->
 
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <app-root></app-root>

--- a/src/styles.css
+++ b/src/styles.css
@@ -71,11 +71,6 @@ code {
   font-size: 16px;
 }
 
-.mat-drawer-inner-container {
-  margin-top: 64px;
-  margin-bottom: -64px;
-}
-
 mat-sidenav.mat-drawer {
   overflow-y: hidden;
 }


### PR DESCRIPTION
Resize the sidenav to make all navigation items readable
Fix menu icon
Restructure toolbar to reduce CSS and HTML complexity
Restructure toolbar and page content structure to be more responsive and avoid horizontal scrollbars due to overflowing toolbar text

Before
<img width="469" alt="ngx-extended-pdf-viewer-before" src="https://github.com/user-attachments/assets/b40640ad-c02b-4636-879b-5e899b4c6111">

After
<img width="467" alt="ngx-extended-pdf-viewer-after" src="https://github.com/user-attachments/assets/2a7c092d-c082-451b-914c-78768395912e">
